### PR TITLE
README: convert to OE instructions

### DIFF
--- a/README
+++ b/README
@@ -2,18 +2,18 @@ ARM Mali BSP layer
 ==================
 
 These recipes provide a BSP layer for ARM development platforms with
-ARM Mali technology enabled.  To build a minimal Poky image for
+ARM Mali technology enabled.  To build a minimal image for
 ODROID-XU3 which features a Mali-T62x GPU.
 
-* Get Poky meta-data with:
-    git clone -b daisy git://git.yoctoproject.org/poky.git
+* Get OE meta-data with:
+    git clone -b daisy git://git.openembedded.org/openembedded-core
 
 * Prepare the build environment:
-    cd poky && source oe-init-build-env
+    cd openembedded-core && git clone -b 1.22 git://git.openembedded.org/bitbake && source oe-init-build-env
 
-* Add path to meta-mali in poky/build/conf/bblayers.conf
+* Add path to meta-mali in openembedded-core/build/conf/bblayers.conf
 
-* Set MACHINE to odroidxu3 in poky/build/conf/local.conf
+* Set MACHINE to odroidxu3 in openembedded-core/build/conf/local.conf
 
 * Build a basic image with:
     bitbake core-image-minimal
@@ -57,7 +57,7 @@ enable the recipes, add this line to local.conf:
 
 Because the Mali recipes provide EGL and OpenGL ES but not OpenGL,
 there is a conflict with the Mesa recipes which are needed for X11 and
-Wayland.  So the current Mali GPU support in Yocto does not work with
+Wayland.  So the current Mali GPU support in OE does not work with
 windowing systems but only "directfb" mode (a.k.a "fbdev").  The
 core-image-minimal includes X11, so to convert it to "directfb" you
 will also need to add these two lines to local.conf:


### PR DESCRIPTION
'Poky' is a non-yocto project compliant distribution (see https://www.yoctoproject.org/ecosystem/compliance-program-registrar) so convert it to regular OE instructions so everyone can use it.

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>